### PR TITLE
Avs guillaume patch massive sim

### DIFF
--- a/Pages/HT_Massive_Simulation/HT_Analytics.md
+++ b/Pages/HT_Massive_Simulation/HT_Analytics.md
@@ -39,4 +39,4 @@ E.g.
 python get_results.py ".\EVAL_ADAS_CTRL\Design of Experiment 1\testcases.xtc" results
 ```
 
-:arrow_right: [Already the end: Get back to Home](../../index.md) :arrow_left: 
+:arrow_right: [Already the end: Get back to Home](../../index.md)

--- a/Pages/HT_Massive_Simulation/HT_Analytics.md
+++ b/Pages/HT_Massive_Simulation/HT_Analytics.md
@@ -1,6 +1,6 @@
 :arrow_left: [Guide 4. Validate test cases under Linux](HT_Validate_test_cases_under_Linux.md)
 
-# How to? analyse all my results
+# Guide 5. How to analyse all my results
 
 Once the simulations have been executed, you’ll get all test cases results (60 in our case).  
 To analyze case by case scenario SCANeR’s users can use SCANeR studio standard “dashboard” (Analyzing Tools for familiar users 😉).  

--- a/Pages/HT_Massive_Simulation/HT_Analytics.md
+++ b/Pages/HT_Massive_Simulation/HT_Analytics.md
@@ -1,4 +1,4 @@
-:arrow_left: [Guide 4. Validate test cases under Linux](HT_Validate_test_cases_under_Linux.md)
+:arrow_left: [Guide 4. Run test cases on Linux](HT_Validate_test_cases_under_Linux.md)
 
 # Guide 5. How to analyse all my results
 

--- a/Pages/HT_Massive_Simulation/HT_Generate_test_cases.md
+++ b/Pages/HT_Massive_Simulation/HT_Generate_test_cases.md
@@ -15,14 +15,19 @@ This guide assumes you’re familiar with SCANeR scenario basis.
 
 ## Step 1. Define template scenario’s parameters and criteria
 
+> * A **parameter** can change in order to create *variability* when generating several versions of a same template scenario.
+> * A **criteria** is a *test* during the simulation to know afterwards what scenario variation succeeded or failed.
+
 When creating a scenario for Massive Simulation it is necessary to make it versatile.  
-To do so we’ll use SCANeR variables.  
-Any type of SCANeR variable can vary: Input, Output or Internal  
-In Step 2 we’ll vary 2 scenario’s parameters: distanceToCollision and rainLevel  
-For this reason, we’ll more focus on those during this Step.  
+To do so we will use script variables. A variable can be Input, Output or Internal  
+In Step 2 we will vary 2 scenario’s parameters: `distanceToCollision` and `rainLevel` 
+
+For this reason, we will more focus on those during this Step.  
 Regarding criteria, it is mandatory to use Output variables.  
-An Output variable makes its content accessible to setup a criteria (e.g. if this Output variable is equal to 1 then it is a success, otherwise it is a failure).  
-In the delivered template scenario, we provide:
+An Output variable makes its content accessible to setup a criteria (e.g. if this Output variable is equal to 1 then it is a success, otherwise it is a failure).
+> `Script Output` > `Scenario Result` > `Scenario Criteria`
+
+In the delivered template scenario `EVAL_ADAS_CTRL.sce`, we provide:
 * 3 Internal variables (`distanceToCollision`, `rainLevel` and `startToBrake`)
 * 2 Output variables (`brakingDistance` and `isCollision`)
 

--- a/Pages/HT_Massive_Simulation/HT_Generate_test_cases.md
+++ b/Pages/HT_Massive_Simulation/HT_Generate_test_cases.md
@@ -1,8 +1,8 @@
-:arrow_left: [Guide 1. Prepare SCANeR workspace under Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
+:arrow_left: [Guide 1. Prepare a workspace for Massive Simulation under Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
 
-# How to generate known and unknown test cases?
+# Guide 2. How to generate known and unknown test cases?
 
-For Massive Simulation application you’ll need a list of scenarios to test and validate your systems under test in known and unknow situations.  
+For Massive Simulation application you will need a list of scenarios to test and validate your systems under test in known and unknow situations.  
 Thanks to SCANeR studio you can prepare template scenario with parameters, criteria of success, failures and so on.  
 These will enable you to automatically generate known and unknown scenarios and measure their performance.  
 

--- a/Pages/HT_Massive_Simulation/HT_Generate_test_cases.md
+++ b/Pages/HT_Massive_Simulation/HT_Generate_test_cases.md
@@ -8,10 +8,10 @@ These will enable you to automatically generate known and unknown scenarios and 
 
 In this guide you’ll see how to
 - Step 1.	Define template scenario’s parameters and criteria
-- Step 2.	Design a test plan to vary parameters and generate X scenarios
+- Step 2.	Design a test plan to vary parameters and generate N scenarios
 
 This guide assumes you’re familiar with SCANeR scenario basis.  
-If not, we highly recommend you to check this article first: [Create a scenario based on your road network](../HT_Create_your_first_test_case/HT_Create_your_first_test_case.md)
+:leftwards_arrow_with_hook: [Create a scenario based on your road network](../HT_Create_your_first_test_case/HT_Create_your_first_test_case.md)
 
 ## Step 1. Define template scenario’s parameters and criteria
 

--- a/Pages/HT_Massive_Simulation/HT_Generate_test_cases.md
+++ b/Pages/HT_Massive_Simulation/HT_Generate_test_cases.md
@@ -1,4 +1,4 @@
-:arrow_left: [Guide 1. Prepare a workspace for Massive Simulation under Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
+:arrow_left: [Guide 1. Prepare SCANeR workspace on Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
 
 # Guide 2. How to generate known and unknown test cases?
 
@@ -112,6 +112,6 @@ We now have to run these! How to? 3 methods:
 * On a simulator, using SCANeR studio, all the produced scenarios are compatible with it. Nevertheless, such process is usually used to test and validate systems Massively, so we would prefer to use SCANeR compute.
 * On HPC/Cloud, SCANeR compute! Here is the one we were looking for and we’ll detail it into the next guide. SCANeR compute is SCANeR studio solver, it enables to run SCANeR simulation on HPC architecture. You’ll be able to handle it within your favorite IT architecture. It is compatible with any HPC platform (e.g. Azure, AWS, Alibaba) and supports any container solutions (e.g. Docker, Kubernetes). You’ll be able to run it in parallel for Massive Simulation application, design your job scheduling, etc.
 
-:arrow_right: [Follow the Guide: 3. Port SCANeR workspace under Linux](HT_Port_SCANeR_workspace_under_Linux.md)
+:arrow_right: [Guide: 3. Port SCANeR workspace on Linux](HT_Port_SCANeR_workspace_under_Linux.md)
 
 

--- a/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
+++ b/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
@@ -25,8 +25,8 @@ To generate known and unknow test cases use SCANeR explore (it takes as an input
 
 ## Let's go !
 
-1. [Prepare the workspace for Massive Simulation under Windows](./HT_Prepare_SCANeR_workspace_under_Windows.md)
-2. [Generate test cases thanks to SCANeR studio, explore under Windows](./HT_Generate_test_cases.md)
-3. [Port SCANeR workspace under Linux](./HT_Port_SCANeR_workspace_under_Linux.md)
-4. [Run test cases thanks to SCANeR compute under Linux](./HT_Validate_test_cases_under_Linux.md)
-5. [SCANeR Analytics](./HT_Analytics.md)
+* Guide 1. [Prepare the workspace for Massive Simulation under Windows](./HT_Prepare_SCANeR_workspace_under_Windows.md)
+* Guide 2. [Generate test cases thanks to SCANeR studio, explore under Windows](./HT_Generate_test_cases.md)
+* Guide 3. [Port SCANeR workspace under Linux](./HT_Port_SCANeR_workspace_under_Linux.md)
+* Guide 4. [Run test cases thanks to SCANeR compute under Linux](./HT_Validate_test_cases_under_Linux.md)
+* Guide 5. [SCANeR Analytics](./HT_Analytics.md)

--- a/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
+++ b/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
@@ -1,11 +1,11 @@
 # How to run a massive simulation to test and validate an ADAS
 
 This guide will walk through the Massive Simulation workflow in SCANeR:
-* Guide 1. [Prepare the workspace for Massive Simulation under Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
-* Guide 2. [Generate test cases thanks to SCANeR studio, explore under Windows](HT_Generate_test_cases.md)
-* Guide 3. [Port SCANeR workspace under Linux](HT_Port_SCANeR_workspace_under_Linux.md)
-* Guide 4. [Run test cases thanks to SCANeR compute under Linux](HT_Validate_test_cases_under_Linux.md)
-* Guide 5. [SCANeR Analytics](HT_Analytics.md)
+* [Guide 1. Prepare SCANeR workspace on Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
+* [Guide 2. Generate test cases on Windows](HT_Generate_test_cases.md)
+* [Guide 3. Port SCANeR workspace on Linux](HT_Port_SCANeR_workspace_under_Linux.md)
+* [Guide 4. Run test cases on Linux](HT_Validate_test_cases_under_Linux.md)
+* [Guide 5. SCANeR Analytics](HT_Analytics.md)
 
 It requires
 * [Foundation Pack](https://www.avsimulation.com/pack-foundation/)
@@ -28,4 +28,4 @@ SCANeR compute is SCANeR studio solver, it enables to run SCANeR simulation on H
 It is compatible with any HPC platform (e.g. Azure, AWS, Alibaba) and supports any container solutions (e.g. Docker, Kubernetes).  
 To generate known and unknow test cases use SCANeR explore (it takes as an input a SCANeR studio test case).
 
-:arrow_right: [Follow the Guide 1: Prepare SCANeR workspace under Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
+:arrow_right: [Guide 1: Prepare SCANeR workspace on Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)

--- a/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
+++ b/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
@@ -17,7 +17,7 @@ You don't have these already? [Get your Trial version of SCANeR](https://www.avs
 
 ![](./assets/SCANeRProducts1.png "SCANeR Products")
 
-SCANeR compute is SCANeR studio solver, it enables to run SCANeR simulation on HPC architecture.  
+SCANeR compute is SCANeR studio solver, it enables to run SCANeR simulation on HPC (High Performance Computing) architecture.  
 It is compatible with any HPC platform (e.g. Azure, AWS, Alibaba) and supports any container solutions (e.g. Docker, Kubernetes).  
 To generate known and unknow test cases use SCANeR explore (it takes as an input a SCANeR studio test case).
 

--- a/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
+++ b/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
@@ -1,6 +1,11 @@
 # How to run a massive simulation to test and validate an ADAS
 
-This guide will walk through the Massive Simulation workflow in SCANeR studio.
+This guide will walk through the Massive Simulation workflow in SCANeR:
+* Guide 1. [Prepare the workspace for Massive Simulation under Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
+* Guide 2. [Generate test cases thanks to SCANeR studio, explore under Windows](HT_Generate_test_cases.md)
+* Guide 3. [Port SCANeR workspace under Linux](HT_Port_SCANeR_workspace_under_Linux.md)
+* Guide 4. [Run test cases thanks to SCANeR compute under Linux](HT_Validate_test_cases_under_Linux.md)
+* Guide 5. [SCANeR Analytics](HT_Analytics.md)
 
 It requires
 * [Foundation Pack](https://www.avsimulation.com/pack-foundation/)
@@ -23,10 +28,4 @@ SCANeR compute is SCANeR studio solver, it enables to run SCANeR simulation on H
 It is compatible with any HPC platform (e.g. Azure, AWS, Alibaba) and supports any container solutions (e.g. Docker, Kubernetes).  
 To generate known and unknow test cases use SCANeR explore (it takes as an input a SCANeR studio test case).
 
-## Let's go !
-
-* Guide 1. [Prepare the workspace for Massive Simulation under Windows](./HT_Prepare_SCANeR_workspace_under_Windows.md)
-* Guide 2. [Generate test cases thanks to SCANeR studio, explore under Windows](./HT_Generate_test_cases.md)
-* Guide 3. [Port SCANeR workspace under Linux](./HT_Port_SCANeR_workspace_under_Linux.md)
-* Guide 4. [Run test cases thanks to SCANeR compute under Linux](./HT_Validate_test_cases_under_Linux.md)
-* Guide 5. [SCANeR Analytics](./HT_Analytics.md)
+:arrow_right: [Follow the Guide 1: Prepare SCANeR workspace under Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)

--- a/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
+++ b/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
@@ -1,11 +1,6 @@
-# How to? run a massive simulation to test and validate an ADAS
+# How to run a massive simulation to test and validate an ADAS
 
-This Quick Starts will guide you to
-* Step 1. Prepare SCANeR workspace under Windows
-* Step 2. Generate test cases thanks to SCANeR studio, explore under Windows
-* Step 3. Port SCANeR workspace under Linux
-* Step 4. Run test cases thanks to SCANeR compute under Linux
-* Step 5. SCANeR Analytics
+This guide will walk through the Massive Simulation workflow in SCANeR studio.
 
 It requires
 * [Foundation Pack](https://www.avsimulation.com/pack-foundation/)
@@ -14,7 +9,7 @@ It requires
 
 You don't have these already? [Get your Trial version of SCANeR](https://www.avsimulation.com/free-download/).
 
-> Tips, If you do not have yet all of the above content no worries 😉  
+> **Tip:** If you do not have yet all of the above content no worries 😉  
 > You can download and use our prepared one: [AEB test case](https://stockage.scanersimulation.com/Evaluation/2021/Massive_Simulation_Pack.7z)  
 > This is the data we'll use in steps below :thumbsup:
 
@@ -26,4 +21,10 @@ SCANeR compute is SCANeR studio solver, it enables to run SCANeR simulation on H
 It is compatible with any HPC platform (e.g. Azure, AWS, Alibaba) and supports any container solutions (e.g. Docker, Kubernetes).  
 To generate known and unknow test cases use SCANeR explore (it takes as an input a SCANeR studio test case).
 
-:arrow_right: [Follow the Guide 1: Prepare SCANeR workspace under Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
+## Let's go !
+
+1. [Prepare the workspace for Massive Simulation under Windows](./HT_Prepare_SCANeR_workspace_under_Windows.md)
+2. [Generate test cases thanks to SCANeR studio, explore under Windows](./HT_Generate_test_cases.md)
+3. [Port SCANeR workspace under Linux](./HT_Port_SCANeR_workspace_under_Linux.md)
+4. [Run test cases thanks to SCANeR compute under Linux](./HT_Validate_test_cases_under_Linux.md)
+5. [SCANeR Analytics](./HT_Analytics.md)

--- a/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
+++ b/Pages/HT_Massive_Simulation/HT_Massive_Simulation.md
@@ -13,6 +13,8 @@ You don't have these already? [Get your Trial version of SCANeR](https://www.avs
 > You can download and use our prepared one: [AEB test case](https://stockage.scanersimulation.com/Evaluation/2021/Massive_Simulation_Pack.7z)  
 > This is the data we'll use in steps below :thumbsup:
 
+You will also need a HPC platform. For the exercise, a simple Linux computer is enough.
+
 ## Principle of operations
 
 ![](./assets/SCANeRProducts1.png "SCANeR Products")

--- a/Pages/HT_Massive_Simulation/HT_Port_SCANeR_workspace_under_Linux.md
+++ b/Pages/HT_Massive_Simulation/HT_Port_SCANeR_workspace_under_Linux.md
@@ -1,4 +1,4 @@
-:arrow_left: [Guide 2. Generate test cases thanks to SCANeR explore under Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
+:arrow_left: [Guide 2. Generate test cases on Windows](HT_Generate_test_cases.md)
 
 # Guide 3. How to port SCANeR workspace under Linux
 
@@ -131,4 +131,4 @@ You should have the following result if you use the configuration we deliver.
 
 ![](./assets/SCANeRWorkspaceDone.png)
 
-:arrow_right: [Follow the Guide 4: Validate the new SCANeR workspace under Linux before to run it on HPC](HT_Validate_test_cases_under_Linux.md)
+:arrow_right: [Guide 4: Run test cases on Linux](HT_Validate_test_cases_under_Linux.md)

--- a/Pages/HT_Massive_Simulation/HT_Port_SCANeR_workspace_under_Linux.md
+++ b/Pages/HT_Massive_Simulation/HT_Port_SCANeR_workspace_under_Linux.md
@@ -1,6 +1,6 @@
 :arrow_left: [Guide 2. Generate test cases thanks to SCANeR explore under Windows](HT_Prepare_SCANeR_workspace_under_Windows.md)
 
-# How to? Port SCANeR workspace under Linux
+# Guide 3. How to port SCANeR workspace under Linux
 
 The SCANeR workspace we made up to now is for Windows (`SAMPLE_COMPUTE_LOCAL`).  
 Use an HPC architecture with a Linux distribution requires to port the Windows SCANeR workspace to Linux.  

--- a/Pages/HT_Massive_Simulation/HT_Prepare_SCANeR_workspace_under_Windows.md
+++ b/Pages/HT_Massive_Simulation/HT_Prepare_SCANeR_workspace_under_Windows.md
@@ -2,13 +2,13 @@
 
 # How to? Prepare SCANeR workspace under Windows
 
-To run SCANeR on an HPC/Cloud architecture (or within container solutions as Docker, Kubernetes, etc.) you need to customize SCANeR workspace in order to prepare it to run without server X11.
+To run SCANeR on an HPC/Cloud architecture (or within container solutions as Docker, Kubernetes, etc.) you need to customize the SCANeR workspace in order to prepare it to run without server X11.
 
-Good news we’ve all you need 👍🏻
+Good news we have all you need 👍🏻
 
 You simply need to configure your SCANeR environment to fit your needs and IT infrastructure. 
 
-In this guide you’ll see
+In this guide you will see
 - Step 1.	Setup essentials SCANeR modules for Massive Simulation
 - Step 2.	Activate non-real-time simulation
 

--- a/Pages/HT_Massive_Simulation/HT_Prepare_SCANeR_workspace_under_Windows.md
+++ b/Pages/HT_Massive_Simulation/HT_Prepare_SCANeR_workspace_under_Windows.md
@@ -15,7 +15,7 @@ In this guide you will see
 ## Step 1. Setup essentials SCANeR modules for Massive Simulation
 
 This guide assumes you know how to create and manage basis of a SCANeR workspace.  
-:arrow_right: [How to create a new workspace](../HT_Create_A_New_Workspace/HT_Create_A_New_Workspace.md)
+:leftwards_arrow_with_hook: [How to create a new workspace](../HT_Create_A_New_Workspace/HT_Create_A_New_Workspace.md)
 In our case we create a SCANeR workspace named `SAMPLE_COMPUTE_LOCAL`  
 
 The essentials modules are the ones using X11 server as

--- a/Pages/HT_Massive_Simulation/HT_Prepare_SCANeR_workspace_under_Windows.md
+++ b/Pages/HT_Massive_Simulation/HT_Prepare_SCANeR_workspace_under_Windows.md
@@ -1,8 +1,8 @@
 :arrow_left: [Home of Massive Simulation](HT_Massive_Simulation.md)
 
-# How to? Prepare SCANeR workspace under Windows
+# How to prepare a workspace for Massive Simulation under Windows
 
-To run SCANeR on an HPC/Cloud architecture (or within container solutions as Docker, Kubernetes, etc.) you need to customize the SCANeR workspace in order to prepare it to run without server X11.
+To run SCANeR on an HPC/Cloud architecture (or within container solutions as Docker, Kubernetes, etc.) you need to customize the SCANeR workspace in order to prepare it to run without server X11 (i.e. without graphical interface).
 
 Good news we have all you need 👍🏻
 
@@ -15,8 +15,9 @@ In this guide you will see
 ## Step 1. Setup essentials SCANeR modules for Massive Simulation
 
 This guide assumes you know how to create and manage basis of a SCANeR workspace.  
-Want to learn more about How to create a SCANeR workspace? [Click here](../HT_Create_A_New_Workspace/HT_Create_A_New_Workspace.md)  
+:arrow_right: [How to create a new workspace](../HT_Create_A_New_Workspace/HT_Create_A_New_Workspace.md)
 In our case we create a SCANeR workspace named `SAMPLE_COMPUTE_LOCAL`  
+
 The essentials modules are the ones using X11 server as
 * SCANeR `VISUAL` or `URENDERER`: driver view
 * SCANeR `ACQUISITION`: cockpit commands
@@ -25,24 +26,24 @@ The essentials modules are the ones using X11 server as
 ### SCANeR `VISUAL` or `URENDERER`: driver view
 To run SCANeR without X11 server you need to remove SCANeR modules which require X11 server as: `VISUAL`, `URENDERER`  
 Depending of your test case you’ll need to add essentials SCANeR modules as:
-* AD/ADAS: SENSORS, LASERMETER, CAMERASENSOR, GPSSENSOR, etc.
-* Headlights: NIGHTTESTMANAGER, AFSMANAGER, etc.
+* AD/ADAS: `SENSORS`, `LASERMETER`, `CAMERASENSOR`, `GPSSENSOR`, etc.
+* Headlights: `NIGHTTESTMANAGER`, `AFSMANAGER`, etc.
 * Etc.
 
 In this guide we’ll use an AD/ADAS test case, let’s add a `SENSORS` module to `SAMPLE_COMPUTE_LOCAL` workspace (we’ll use it to control a radar).  
-> Tips, `SENSORS` module supports as many functional sensors as the CPU/GPU is able to process.  
+> **Tips:** `SENSORS` module supports as many functional sensors as the CPU/GPU is able to process.  
 > These sensors are: radars, logical cameras (generates logical information, not images), lighting sensors, E-Horizon and ultra-sonic sensors.  
 
 ### SCANeR `ACQUISITION`: cockpit commands
 
 SCANeR `ACQUISITION` module is available in two modes with or without GUI.  
 Let’s make sure than that it is set in non-GUI mode.  
-To do so edit the `ACQUISITION` module and make sure that the following both options are checked: hide window, start without GUI (no X)
+To do so edit the `ACQUISITION` module and make sure that the following both options are checked: hide window, start without GUI (no X)  
 ![](./assets/AcquisitionNoX.png)
 
 ### SCANeR 'OFFLINESCHEDULER': simulation orchestrator
 
-The `OFFLINESCHEDULER` is an orchestrator, it enables to control SCANeR modules’ execution; step by step.  
+The `OFFLINESCHEDULER` is an orchestrator, it enables to control SCANeR modules’ execution step by step.  
 Edit its settings and make sure that the step period and the synchronization is fine.  
 In our case the step period is 50 ms (1/20)  
 ![](./assets/OfflineschedulerIndex.png)

--- a/Pages/HT_Massive_Simulation/HT_Prepare_SCANeR_workspace_under_Windows.md
+++ b/Pages/HT_Massive_Simulation/HT_Prepare_SCANeR_workspace_under_Windows.md
@@ -15,7 +15,7 @@ In this guide you will see
 ## Step 1. Setup essentials SCANeR modules for Massive Simulation
 
 This guide assumes you know how to create and manage basis of a SCANeR workspace.  
-:leftwards_arrow_with_hook: [How to create a new workspace](../HT_Create_A_New_Workspace/HT_Create_A_New_Workspace.md)
+:leftwards_arrow_with_hook: [How to create a new workspace](../HT_Create_A_New_Workspace/HT_Create_A_New_Workspace.md)  
 In our case we create a SCANeR workspace named `SAMPLE_COMPUTE_LOCAL`  
 
 The essentials modules are the ones using X11 server as

--- a/Pages/HT_Massive_Simulation/HT_Prepare_SCANeR_workspace_under_Windows.md
+++ b/Pages/HT_Massive_Simulation/HT_Prepare_SCANeR_workspace_under_Windows.md
@@ -1,6 +1,6 @@
 :arrow_left: [Home of Massive Simulation](HT_Massive_Simulation.md)
 
-# How to prepare a workspace for Massive Simulation under Windows
+# Guide 1. How to prepare a workspace for Massive Simulation under Windows
 
 To run SCANeR on an HPC/Cloud architecture (or within container solutions as Docker, Kubernetes, etc.) you need to customize the SCANeR workspace in order to prepare it to run without server X11 (i.e. without graphical interface).
 

--- a/Pages/HT_Massive_Simulation/HT_Validate_test_cases_under_Linux.md
+++ b/Pages/HT_Massive_Simulation/HT_Validate_test_cases_under_Linux.md
@@ -1,6 +1,6 @@
 :arrow_left: [Guide 3. Port SCANeR workspace under Linux](HT_Port_SCANeR_workspace_under_Linux.md)
 
-# How to? Validate the new SCANeR workspace for Linux before to run it on HPC
+# Guide 4. How to validate the new SCANeR workspace for Linux before to run it on HPC
 
 Perform local test enables you to make sure that you did not miss anything before to run Massive Simulation.  
 It’s easy, simply run your test cases with SCANeR compute. To do so run  

--- a/Pages/HT_Massive_Simulation/HT_Validate_test_cases_under_Linux.md
+++ b/Pages/HT_Massive_Simulation/HT_Validate_test_cases_under_Linux.md
@@ -1,4 +1,4 @@
-:arrow_left: [Guide 3. Port SCANeR workspace under Linux](HT_Port_SCANeR_workspace_under_Linux.md)
+:arrow_left: [Guide 3. Port SCANeR workspace on Linux](HT_Port_SCANeR_workspace_under_Linux.md)
 
 # Guide 4. How to validate the new SCANeR workspace for Linux before to run it on HPC
 
@@ -26,4 +26,4 @@ Here is a list of the remaining actions on your side, we offer services on deman
 SCANeR Standalone method supports any container solutions (e.g. Docker, Kubernetes).
 Ask us for details 😉
 
-:arrow_right: [Follow the Guide 5: SCANeR Analytics](HT_Analytics.md)
+:arrow_right: [Guide 5: SCANeR Analytics](HT_Analytics.md)


### PR DESCRIPTION
- Mettre la liste des « sous-chapitres » à la fin de « Home » plutôt que au début, avec des liens cliquables ?
(remplace le lien « next » exceptionnellement, vu que c’est un article d’introduction / home)

- « How to? Prepare SCANeR workspace under Windows »  “How to prepare SCANeR workspace **for Massive Simulation** under Windows”

- Je suis d’accord avec Christian pour éviter les contractions « we’ll », « we’ve ».
Comme on est Français c’est à mon avis plus perçu comme une maladresse qu’un niveau de langage natif décontracté.

- « Steps 1, 2, … » au niveau des « sous-chapitres » mais pas au niveau du « home » (ou l’inverse) pour éviter la confusion.* --> J'ai remplacé par "Guide 1, 2, ..." au niveau du "home"
